### PR TITLE
40272408 - Removed deprected class

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/publicapi/StartRecording.java
+++ b/src/main/java/de/dennisguse/opentracks/publicapi/StartRecording.java
@@ -22,7 +22,6 @@ public class StartRecording extends AbstractAPIActivity {
     public static final String EXTRA_STATS_TARGET_PACKAGE = "STATS_TARGET_PACKAGE";
     public static final String EXTRA_STATS_TARGET_CLASS = "STATS_TARGET_CLASS";
 
-    private static final String TAG = StartRecording.class.getSimpleName();
 
     protected void execute(TrackRecordingService service) {
         Track.Id trackId = service.startNewTrack();

--- a/src/main/java/de/dennisguse/opentracks/publicapi/StartRecording.java
+++ b/src/main/java/de/dennisguse/opentracks/publicapi/StartRecording.java
@@ -41,12 +41,11 @@ public class StartRecording extends AbstractAPIActivity {
         ContentProviderUtils contentProviderUtils = new ContentProviderUtils(this);
         Track track = contentProviderUtils.getTrack(trackId);
 
-        TrackUtils.updateTrack(this, track,
-                bundle.getString(EXTRA_TRACK_NAME, null),
-                bundle.getString(EXTRA_TRACK_ACTIVITY_TYPE_LOCALIZED, null),
-                ActivityType.findBy(bundle.getString(EXTRA_TRACK_ACTIVITY_TYPE_ID, null)),
-                bundle.getString(EXTRA_TRACK_DESCRIPTION, null),
-                contentProviderUtils);
+        
+
+        contentProviderUtils.updateTrack(track);
+
+        
     }
 
     private void startDashboardAPI(@NonNull Track.Id trackId, @NonNull Bundle bundle) {


### PR DESCRIPTION
Removed the unused variable "TAG" #17 

The "TrackUtils" class is marked as deprecated, which means it is no longer recommended for use and may be removed in future releases. Ignoring deprecation warnings can lead to potential issues and reduced code maintainability.

